### PR TITLE
fix: capture config check

### DIFF
--- a/src/graphics_capture_api.rs
+++ b/src/graphics_capture_api.rs
@@ -278,7 +278,7 @@ impl GraphicsCaptureApi {
         }
 
         // Config
-        if self.capture_cursor.is_some() {
+        if self.capture_cursor.unwrap_or(false) {
             if ApiInformation::IsPropertyPresent(
                 &HSTRING::from("Windows.Graphics.Capture.GraphicsCaptureSession"),
                 &HSTRING::from("IsCursorCaptureEnabled"),
@@ -292,7 +292,7 @@ impl GraphicsCaptureApi {
             }
         }
 
-        if self.draw_border.is_some() {
+        if self.draw_border.unwrap_or(false) {
             if ApiInformation::IsPropertyPresent(
                 &HSTRING::from("Windows.Graphics.Capture.GraphicsCaptureSession"),
                 &HSTRING::from("IsBorderRequired"),


### PR DESCRIPTION
There are three different conditions:
1. Ok(true)
2. Ok(false)
3. None

And only the first condition should be take as `true` here.