### PR TITLE
Use isize instead of HWND

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -216,16 +216,16 @@ impl Window {
     ///
     /// # Arguments
     ///
-    /// * `window` - The raw HWND.
+    /// * `hwnd` - The hwnd.
     #[must_use]
-    pub const fn from_raw_hwnd(window: HWND) -> Self {
-        Self { window }
+    pub const fn from_raw_hwnd(hwnd: isize) -> Self {
+        Self { window: HWND(hwnd)}
     }
 
     /// Returns the raw HWND of the window.
     #[must_use]
-    pub const fn as_raw_hwnd(&self) -> HWND {
-        self.window
+    pub const fn as_raw_hwnd(&self) -> isize {
+        self.window.0
     }
 
     // Callback used for enumerating all windows.
@@ -245,7 +245,7 @@ impl TryFrom<Window> for GraphicsCaptureItem {
     type Error = Error;
 
     fn try_from(value: Window) -> Result<Self, Self::Error> {
-        let window = value.as_raw_hwnd();
+        let window = HWND(value.as_raw_hwnd());
 
         let interop = windows::core::factory::<Self, IGraphicsCaptureItemInterop>()?;
         Ok(unsafe { interop.CreateForWindow(window)? })


### PR DESCRIPTION
During my usage, I need to specify hwnd, but the Windows crate I am using and the version of Windows crate used by [windows-capture](https://github.com/NiiightmareXD/windows-capture) are different. I think it is better to use isize instead of HWND.