### PR TITLE
Relax lifetime restrictions on `as_raw_buffer`, `as_raw_nopadding_buffer`, and `save_as_image` for `windows_capture::frame::FrameBuffer`

### DIFF
--- a/src/frame.rs
+++ b/src/frame.rs
@@ -445,7 +445,7 @@ impl<'a> FrameBuffer<'a> {
 
     /// Get the raw pixel data with possible padding.
     #[must_use]
-    pub fn as_raw_buffer(&'a mut self) -> &'a mut [u8] {
+    pub fn as_raw_buffer(&mut self) -> &mut [u8] {
         self.raw_buffer
     }
 
@@ -454,7 +454,7 @@ impl<'a> FrameBuffer<'a> {
     /// # Returns
     ///
     /// A mutable reference to the buffer containing pixel data without padding.
-    pub fn as_raw_nopadding_buffer(&'a mut self) -> Result<&'a mut [u8], Error> {
+    pub fn as_raw_nopadding_buffer(&mut self) -> Result<&mut [u8], Error> {
         if !self.has_padding() {
             return Ok(self.raw_buffer);
         }
@@ -493,7 +493,7 @@ impl<'a> FrameBuffer<'a> {
     ///
     /// An `Ok` result if the image is successfully saved, or an `Err` result if there was an error.
     pub fn save_as_image<T: AsRef<Path>>(
-        &'a mut self,
+        &mut self,
         path: T,
         format: ImageFormat,
     ) -> Result<(), Error> {


### PR DESCRIPTION
We probably intend these lifetimes to look like:
```diff
 impl<'a> FrameBuffer<'a> {
-    pub fn as_raw_buffer(&'a mut self) -> &'a mut [u8] {
+    pub fn as_raw_buffer<'b>(&'b mut self) -> &'b mut [u8] {
         self.raw_buffer
     }
```
which is equivalent to letting the lifetimes be inferred I think.

Hope this PR helps, let me know if there are any changes you'd like, thanks!

---

For some context, this was preventing me from writing a function like:
```rust
    fn from_frame_buffer<'a, 'fb: 'a>(frame_buffer: &'a mut FrameBuffer<'fb>) -> Self {
        let buffer = frame_buffer.as_raw_buffer().to_vec();
        let width = frame_buffer.width();
```
and I would get an error like:
```text
error[E0502]: cannot borrow `*frame_buffer` as immutable because it is also borrowed as mutable
  --> src/main.rs:45:26
   |
43 |     fn from_frame_buffer<'a, 'fb: 'a>(frame_buffer: &'a mut FrameBuffer<'fb>) -> Self {
   |                              --- lifetime `'fb` defined here
44 |         let buffer: Vec<u8> = frame_buffer.as_raw_buffer().to_vec();
   |                               ----------------------------
   |                               |
   |                               mutable borrow occurs here
   |                               argument requires that `*frame_buffer` is borrowed for `'fb`
45 |         let width: u32 = frame_buffer.width();
   |                          ^^^^^^^^^^^^ immutable borrow occurs here
```
Essentially when I call `frame_buffer.as_raw_buffer()`, it tries to borrow it for the lifetime of `'fb` above, which is probably not what we want (I just wanna borrow it just for this statement, not for the whole `'fb` lifetime).