### PR TITLE
fix: added code to set height and width of the output frame

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -231,6 +231,12 @@ impl VideoEncoder {
                 MediaEncodingProfile::CreateWmv(VideoEncodingQuality(encoder_quality as i32))?
             }
         };
+        media_encoding_profile
+            .Video()?
+            .SetWidth(width)?;
+        media_encoding_profile
+            .Video()?
+            .SetHeight(height)?;
 
         let video_encoding_properties = VideoEncodingProperties::CreateUncompressed(
             &MediaEncodingSubtypes::Bgra8()?,


### PR DESCRIPTION
The output frame size received from the encoder was always dependent on the VideoEncodingQuality
Which holds the values and the output size as follow:

Auto - {ERROR}
HD1080p - 1920 x 1080
HD720p - 1280 x 720
Wvga - 800 x 480
Ntsc - 720 x 480
Pal - 720 x 576
Vga - 640 x 480
Qvga - 320 x 240
Uhd2160p - 3840 x 2160
Uhd4320p - {ERROR}

In the code I am setting the output frame's width and height based on the size passed from the props when initializing the encoder.