### PR TITLE
Added a way to access frame texture

### DIFF
--- a/src/frame.rs
+++ b/src/frame.rs
@@ -156,12 +156,12 @@ impl<'a> Frame<'a> {
         self.frame_surface.clone()
     }
 
-    /// Get the frame buffer.
+    /// Get the raw texture of the frame.
     ///
     /// # Returns
     ///
-    /// The FrameBuffer containing the frame data.
-    pub fn buffer(&mut self) -> Result<FrameBuffer, Error> {
+    /// The ID3D11Texture2D representing the raw texture of the frame.
+    pub fn texture(&self) -> Result<ID3D11Texture2D, Error> {
         // Texture Settings
         let texture_desc = D3D11_TEXTURE2D_DESC {
             Width: self.width,
@@ -185,7 +185,18 @@ impl<'a> Frame<'a> {
             self.d3d_device
                 .CreateTexture2D(&texture_desc, None, Some(&mut texture))?;
         };
+        
         let texture = texture.unwrap();
+        Ok(texture)
+    }
+
+    /// Get the frame buffer.
+    ///
+    /// # Returns
+    ///
+    /// The FrameBuffer containing the frame data.
+    pub fn buffer(&mut self) -> Result<FrameBuffer, Error> {
+        let texture = self.texture()?;
 
         // Copy the real texture to copy texture
         unsafe {

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -187,6 +187,12 @@ impl<'a> Frame<'a> {
         };
         
         let texture = texture.unwrap();
+        
+        // Copy the real texture to copy texture
+        unsafe {
+            self.context.CopyResource(&texture, &self.frame_texture);
+        };
+
         Ok(texture)
     }
 
@@ -197,11 +203,6 @@ impl<'a> Frame<'a> {
     /// The FrameBuffer containing the frame data.
     pub fn buffer(&mut self) -> Result<FrameBuffer, Error> {
         let texture = self.texture()?;
-
-        // Copy the real texture to copy texture
-        unsafe {
-            self.context.CopyResource(&texture, &self.frame_texture);
-        };
 
         // Map the texture to enable CPU access
         let mut mapped_resource = D3D11_MAPPED_SUBRESOURCE::default();


### PR DESCRIPTION
First of all, I found that it is currently impossible to scale the frame and convert the color space, which makes it difficult to use in some projects. For example, I currently need to obtain NV12 textures, and I want to scale the frame directly because the size I need is not necessarily the size of the screen, it will normally be smaller.

If you are on Windows, if you want to properly utilize hardware acceleration, and your project also uses the D3D interface at the bottom, then using [`Video Processor MFT`](https://learn.microsoft.com/en-us/windows/win32/medfound/video-processor-mft) is a very good choice.

If you want to handle the conversion process more efficiently and avoid frequent memory copy operations between the CPU and GPU, getting the texture directly from the frame is a better way. I can directly pass the texture into `IMFTransform`.

I think `Video Processor MFT` is a better way to implement frame conversion in the current project. Have you considered integrating this part into the current project?