### PR TITLE
Feature/record cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,55 @@
 version = 3
 
 [[package]]
+name = "anstream"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19,6 +68,58 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "clap"
+version = "4.5.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "crossbeam-deque"
@@ -46,6 +147,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
+name = "ctrlc"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90eeab0aa92f3f9b4e87f258c72b139c207d251f9cbc1080a0086b86a8870dd3"
+dependencies = [
+ "nix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -62,6 +173,12 @@ name = "indoc"
 version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "libc"
@@ -86,6 +203,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -246,6 +375,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -295,6 +430,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "windows"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,6 +449,8 @@ dependencies = [
 name = "windows-capture"
 version = "1.3.6"
 dependencies = [
+ "clap",
+ "ctrlc",
  "parking_lot",
  "rayon",
  "thiserror",
@@ -374,6 +517,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
  "windows-result",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
  "windows-targets",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,8 @@ rayon = "1.10.0"
 
 # Error handling
 thiserror = "1.0.63"
+clap = { version = "4.5.17", features = ["derive"] }
+ctrlc = "3.4.5"
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -200,6 +200,7 @@ fn main() {
     }
 
     if let Some(window_name) = cli.window_name {
+        // may use Window::foreground() instead
         let capture_item =
             Window::from_contains_name(&window_name).expect("Window not found!");
 
@@ -225,6 +226,7 @@ fn main() {
             capture_settings,
         );
     } else if let Some(index) = cli.monitor_index {
+        // may use Monitor::primary() instead
         let capture_item =
             Monitor::from_index(usize::try_from(index).unwrap()).expect("Monitor not found!");
 

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -1,0 +1,184 @@
+use std::{
+    io::{self, Write},
+    time::Instant,
+};
+
+use clap::Parser;
+
+use windows_capture::{
+    capture::GraphicsCaptureApiHandler,
+    encoder::{
+        AudioSettingsBuilder, ContainerSettingsBuilder, VideoEncoder, VideoSettingsBuilder,
+    },
+    frame::Frame,
+    graphics_capture_api::InternalCaptureControl,
+    monitor::Monitor,
+    settings::{ColorFormat, CursorCaptureSettings, DrawBorderSettings, Settings},
+    window::Window,
+};
+
+use windows::Graphics::Capture::GraphicsCaptureItem;
+
+// This struct will be used to handle the capture events.
+struct Capture {
+    // The video encoder that will be used to encode the frames.
+    encoder: Option<VideoEncoder>,
+    // To measure the time the capture has been running
+    start: Instant,
+    // To count the number of frames captured
+    frame_count: u64,
+}
+
+impl GraphicsCaptureApiHandler for Capture {
+    // The type of flags used to get the values from the settings.
+    type Flags = String;
+
+    // The type of error that can occur during capture, the error will be returned from `CaptureControl` and `start` functions.
+    type Error = Box<dyn std::error::Error + Send + Sync>;
+
+    // Function that will be called to create the struct. The flags can be passed from settings.
+    fn new(message: Self::Flags) -> Result<Self, Self::Error> {
+        println!("Got The Flag: {message}");
+
+        let encoder = VideoEncoder::new(
+            VideoSettingsBuilder::new(1920, 1080),
+            AudioSettingsBuilder::default().disabled(true),
+            ContainerSettingsBuilder::default(),
+            "video.mp4",
+        )?;
+
+        Ok(Self {
+            encoder: Some(encoder),
+            start: Instant::now(),
+            frame_count: 0,
+        })
+    }
+
+    // Called every time a new frame is available.
+    fn on_frame_arrived(
+        &mut self,
+        frame: &mut Frame,
+        capture_control: InternalCaptureControl,
+    ) -> Result<(), Self::Error> {
+        self.frame_count += 1;
+
+        let elapsed_secs = self.start.elapsed().as_secs_f64();
+        let fps = self.frame_count as f64 / elapsed_secs;
+
+        print!(
+            "\rRecording for: {:.2} seconds | FPS: {:.2}",
+            elapsed_secs, fps
+        );
+        io::stdout().flush()?;
+
+        // Send the frame to the video encoder
+        self.encoder.as_mut().unwrap().send_frame(frame)?;
+
+        // Stop the capture after 6 seconds
+        if self.start.elapsed().as_secs() >= 6 {
+            // Finish the encoder and save the video.
+            self.encoder.take().unwrap().finish()?;
+
+            capture_control.stop();
+
+            // Because there wasn't any new lines in previous prints
+            println!();
+        }
+
+        Ok(())
+    }
+
+    // Optional handler called when the capture item (usually a window) closes.
+    fn on_closed(&mut self) -> Result<(), Self::Error> {
+        println!("Capture Session Closed");
+
+        Ok(())
+    }
+}
+
+#[derive(Parser)]
+#[command(name = "Screen Capture")]
+#[command(version = "1.0")]
+#[command(author = "Your Name")]
+#[command(about = "Captures the screen")]
+struct Cli {
+    /// Window name to capture
+    #[arg(long, conflicts_with = "monitor_index")]
+    window_name: Option<String>,
+
+    /// Monitor index to capture
+    #[arg(long, conflicts_with = "window_name")]
+    monitor_index: Option<u32>,
+
+    /// Cursor capture settings: always, never, default
+    #[arg(long, default_value = "default")]
+    cursor_capture: String,
+
+    /// Draw border settings: always, never, default
+    #[arg(long, default_value = "default")]
+    draw_border: String,
+}
+
+fn parse_cursor_capture(s: &str) -> CursorCaptureSettings {
+    match s.to_lowercase().as_str() {
+        "always" => CursorCaptureSettings::WithCursor,
+        "never" => CursorCaptureSettings::WithoutCursor,
+        "default" => CursorCaptureSettings::Default,
+        _ => {
+            eprintln!("Invalid cursor_capture value: {}", s);
+            std::process::exit(1);
+        }
+    }
+}
+
+fn parse_draw_border(s: &str) -> DrawBorderSettings {
+    match s.to_lowercase().as_str() {
+        "always" => DrawBorderSettings::WithBorder,
+        "never" => DrawBorderSettings::WithoutBorder,
+        "default" => DrawBorderSettings::Default,
+        _ => {
+            eprintln!("Invalid draw_border value: {}", s);
+            std::process::exit(1);
+        }
+    }
+}
+
+fn start_capture<T>(
+    capture_item: T,
+    cursor_capture: CursorCaptureSettings,
+    draw_border: DrawBorderSettings,
+) where
+    T: TryInto<GraphicsCaptureItem>,
+{
+    let settings = Settings::new(
+        capture_item,
+        cursor_capture,
+        draw_border,
+        ColorFormat::Rgba8,
+        "Yea This Works".to_string(),
+    );
+
+    // Starts the capture and takes control of the current thread.
+    // The errors from handler trait will end up here
+    Capture::start(settings).expect("Screen Capture Failed");
+}
+
+fn main() {
+    let cli = Cli::parse();
+
+    let cursor_capture = parse_cursor_capture(&cli.cursor_capture);
+    let draw_border = parse_draw_border(&cli.draw_border);
+
+    if let Some(window_name) = cli.window_name {
+        let capture_item =
+            Window::from_contains_name(&window_name).expect("Window not found!");
+        start_capture(capture_item, cursor_capture, draw_border);
+    } else if let Some(index) = cli.monitor_index {
+        let capture_item =
+            Monitor::from_index(usize::try_from(index).unwrap()).expect("Monitor not found!");
+        start_capture(capture_item, cursor_capture, draw_border);
+    } else {
+        eprintln!("Either --window-name or --monitor-index must be provided");
+        std::process::exit(1);
+    }
+}

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -132,14 +132,6 @@ struct Cli {
     #[arg(long, default_value = "default")]
     draw_border: String,
 
-    /// Video width
-    #[arg(long, default_value_t = 1920)]
-    width: u32,
-
-    /// Video height
-    #[arg(long, default_value_t = 1080)]
-    height: u32,
-
     /// Output file path
     #[arg(long, default_value = "video.mp4")]
     path: String,
@@ -207,16 +199,25 @@ fn main() {
         .expect("Error setting Ctrl-C handler");
     }
 
-    let capture_settings = CaptureSettings {
-        stop_flag: stop_flag.clone(),
-        width: cli.width,
-        height: cli.height,
-        path: cli.path.clone(),
-    };
-
     if let Some(window_name) = cli.window_name {
         let capture_item =
             Window::from_contains_name(&window_name).expect("Window not found!");
+
+        // Automatically detect window's width and height
+        let rect = capture_item.rect().expect("Failed to get window rect");
+        let width = (rect.right - rect.left) as u32;
+        let height = (rect.bottom - rect.top) as u32;
+
+        let capture_settings = CaptureSettings {
+            stop_flag: stop_flag.clone(),
+            width,
+            height,
+            path: cli.path.clone(),
+        };
+
+        println!("Window title: {}", window_name);
+        println!("Window size: {}x{}", width, height);
+
         start_capture(
             capture_item,
             cursor_capture,
@@ -226,6 +227,21 @@ fn main() {
     } else if let Some(index) = cli.monitor_index {
         let capture_item =
             Monitor::from_index(usize::try_from(index).unwrap()).expect("Monitor not found!");
+
+        // Automatically detect monitor's width and height
+        let width = capture_item.width().expect("Failed to get monitor width");
+        let height = capture_item.height().expect("Failed to get monitor height");
+
+        let capture_settings = CaptureSettings {
+            stop_flag: stop_flag.clone(),
+            width,
+            height,
+            path: cli.path.clone(),
+        };
+
+        println!("Monitor index: {}", index);
+        println!("Monitor size: {}x{}", width, height);
+
         start_capture(
             capture_item,
             cursor_capture,

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -23,6 +23,14 @@ use windows_capture::{
 
 use windows::Graphics::Capture::GraphicsCaptureItem;
 
+// Struct to hold capture settings
+struct CaptureSettings {
+    stop_flag: Arc<AtomicBool>,
+    width: u32,
+    height: u32,
+    path: String,
+}
+
 // This struct will be used to handle the capture events.
 struct Capture {
     // The video encoder that will be used to encode the frames.
@@ -31,33 +39,33 @@ struct Capture {
     start: Instant,
     // To count the number of frames captured
     frame_count: u64,
-    // Flag to check if recording should stop
-    stop_flag: Arc<AtomicBool>,
+    // Capture settings including stop flag and video settings
+    settings: CaptureSettings,
 }
 
 impl GraphicsCaptureApiHandler for Capture {
     // The type of flags used to get the values from the settings.
-    type Flags = Arc<AtomicBool>;
+    type Flags = CaptureSettings;
 
     // The type of error that can occur during capture, the error will be returned from `CaptureControl` and `start` functions.
     type Error = Box<dyn std::error::Error + Send + Sync>;
 
     // Function that will be called to create the struct. The flags can be passed from settings.
-    fn new(stop_flag: Self::Flags) -> Result<Self, Self::Error> {
+    fn new(settings: Self::Flags) -> Result<Self, Self::Error> {
         println!("Capture started.");
 
         let encoder = VideoEncoder::new(
-            VideoSettingsBuilder::new(1920, 1080),
+            VideoSettingsBuilder::new(settings.width, settings.height),
             AudioSettingsBuilder::default().disabled(true),
             ContainerSettingsBuilder::default(),
-            "video.mp4",
+            &settings.path,
         )?;
 
         Ok(Self {
             encoder: Some(encoder),
             start: Instant::now(),
             frame_count: 0,
-            stop_flag,
+            settings,
         })
     }
 
@@ -82,7 +90,7 @@ impl GraphicsCaptureApiHandler for Capture {
         self.encoder.as_mut().unwrap().send_frame(frame)?;
 
         // Stop the capture if stop_flag is set
-        if self.stop_flag.load(Ordering::SeqCst) {
+        if self.settings.stop_flag.load(Ordering::SeqCst) {
             // Finish the encoder and save the video.
             self.encoder.take().unwrap().finish()?;
 
@@ -123,6 +131,18 @@ struct Cli {
     /// Draw border settings: always, never, default
     #[arg(long, default_value = "default")]
     draw_border: String,
+
+    /// Video width
+    #[arg(long, default_value_t = 1920)]
+    width: u32,
+
+    /// Video height
+    #[arg(long, default_value_t = 1080)]
+    height: u32,
+
+    /// Output file path
+    #[arg(long, default_value = "video.mp4")]
+    path: String,
 }
 
 fn parse_cursor_capture(s: &str) -> CursorCaptureSettings {
@@ -153,21 +173,21 @@ fn start_capture<T>(
     capture_item: T,
     cursor_capture: CursorCaptureSettings,
     draw_border: DrawBorderSettings,
-    stop_flag: Arc<AtomicBool>,
+    settings: CaptureSettings,
 ) where
     T: TryInto<GraphicsCaptureItem>,
 {
-    let settings = Settings::new(
+    let capture_settings = Settings::new(
         capture_item,
         cursor_capture,
         draw_border,
         ColorFormat::Rgba8,
-        stop_flag.clone(),
+        settings,
     );
 
     // Starts the capture and takes control of the current thread.
     // The errors from handler trait will end up here
-    Capture::start(settings).expect("Screen Capture Failed");
+    Capture::start(capture_settings).expect("Screen Capture Failed");
 }
 
 fn main() {
@@ -187,14 +207,31 @@ fn main() {
         .expect("Error setting Ctrl-C handler");
     }
 
+    let capture_settings = CaptureSettings {
+        stop_flag: stop_flag.clone(),
+        width: cli.width,
+        height: cli.height,
+        path: cli.path.clone(),
+    };
+
     if let Some(window_name) = cli.window_name {
         let capture_item =
             Window::from_contains_name(&window_name).expect("Window not found!");
-        start_capture(capture_item, cursor_capture, draw_border, stop_flag);
+        start_capture(
+            capture_item,
+            cursor_capture,
+            draw_border,
+            capture_settings,
+        );
     } else if let Some(index) = cli.monitor_index {
         let capture_item =
             Monitor::from_index(usize::try_from(index).unwrap()).expect("Monitor not found!");
-        start_capture(capture_item, cursor_capture, draw_border, stop_flag);
+        start_capture(
+            capture_item,
+            cursor_capture,
+            draw_border,
+            capture_settings,
+        );
     } else {
         eprintln!("Either --window-name or --monitor-index must be provided");
         std::process::exit(1);

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -216,7 +216,7 @@ fn main() {
             path: cli.path.clone(),
         };
 
-        println!("Window title: {}", window_name);
+        println!("Window title: {}", capture_item.title().expect("Failed to get window title"));
         println!("Window size: {}x{}", width, height);
 
         start_capture(

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -29,6 +29,8 @@ struct CaptureSettings {
     width: u32,
     height: u32,
     path: String,
+    bitrate: u32,
+    frame_rate: u32,
 }
 
 // This struct will be used to handle the capture events.
@@ -56,8 +58,12 @@ impl GraphicsCaptureApiHandler for Capture {
     fn new(settings: Self::Flags) -> Result<Self, Self::Error> {
         println!("Capture started.");
 
+        let video_settings = VideoSettingsBuilder::new(settings.width, settings.height)
+            .bitrate(settings.bitrate)
+            .frame_rate(settings.frame_rate);
+
         let encoder = VideoEncoder::new(
-            VideoSettingsBuilder::new(settings.width, settings.height),
+            video_settings,
             AudioSettingsBuilder::default().disabled(true),
             ContainerSettingsBuilder::default(),
             &settings.path,
@@ -146,6 +152,14 @@ struct Cli {
     /// Output file path
     #[arg(long, default_value = "video.mp4")]
     path: String,
+
+    /// Video bitrate in bits per second
+    #[arg(long, default_value_t = 15_000_000)]
+    bitrate: u32,
+
+    /// Video frame rate
+    #[arg(long, default_value_t = 60)]
+    frame_rate: u32,
 }
 
 fn parse_cursor_capture(s: &str) -> CursorCaptureSettings {
@@ -225,6 +239,8 @@ fn main() {
             width,
             height,
             path: cli.path.clone(),
+            bitrate: cli.bitrate,
+            frame_rate: cli.frame_rate,
         };
 
         println!(
@@ -253,6 +269,8 @@ fn main() {
             width,
             height,
             path: cli.path.clone(),
+            bitrate: cli.bitrate,
+            frame_rate: cli.frame_rate,
         };
 
         println!("Monitor index: {}", index);

--- a/src/window.rs
+++ b/src/window.rs
@@ -11,8 +11,9 @@ use windows::{
         },
         UI::WindowsAndMessaging::{
             EnumChildWindows, FindWindowW, GetClientRect, GetDesktopWindow, GetForegroundWindow,
-            GetWindowLongPtrW, GetWindowTextLengthW, GetWindowTextW, GetWindowThreadProcessId,
-            IsWindowVisible, GWL_EXSTYLE, GWL_STYLE, WS_CHILD, WS_EX_TOOLWINDOW,
+            GetWindowLongPtrW, GetWindowRect, GetWindowTextLengthW, GetWindowTextW,
+            GetWindowThreadProcessId, IsWindowVisible, GWL_EXSTYLE, GWL_STYLE, WS_CHILD,
+            WS_EX_TOOLWINDOW,
         },
     },
 };
@@ -156,6 +157,22 @@ impl Window {
             None
         } else {
             Some(Monitor::from_raw_hmonitor(monitor.0))
+        }
+    }
+
+    /// Returns the rectangle of the window in screen coordinates.
+    ///
+    /// # Errors
+    ///
+    /// Returns an `Error::WindowsError` if there is an error retrieving the window rectangle.
+    #[inline]
+    pub fn rect(&self) -> Result<RECT, Error> {
+        let mut rect = RECT::default();
+        let result = unsafe { GetWindowRect(self.window, &mut rect) };
+        if result.is_ok() {
+            Ok(rect)
+        } else {
+            Err(Error::WindowsError(windows::core::Error::from_win32()))
         }
     }
 


### PR DESCRIPTION
I added CLI executable to record given window name or monitor index. This CLI executable will work as example of this library's application.

Features
- get window_name or monitor_index
- get cursor_capture and draw_border
- get path
- show up FPS of capture(which is NOT recorded video files fps)
- graceful exit with ctrl+c
- automatically detect window / monitor 's height/width and save into video file


Some minor concerns
- Is it okay to maintain the CLI's Cargo dependencies together with the main project's dependencies?