### PR TITLE
Zero copy and get direct3d device and context

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use windows_capture::{
-    capture::GraphicsCaptureApiHandler,
+    capture::{GraphicsCaptureApiHandler, RawDirect3DDevice},
     encoder::{AudioSettingsBuilder, ContainerSettingsBuilder, VideoEncoder, VideoSettingsBuilder},
     frame::Frame,
     graphics_capture_api::InternalCaptureControl,
@@ -28,7 +28,7 @@ impl GraphicsCaptureApiHandler for Capture {
     type Error = Box<dyn std::error::Error + Send + Sync>;
 
     // Function that will be called to create the struct. The flags can be passed from settings.
-    fn new(message: Self::Flags) -> Result<Self, Self::Error> {
+    fn new(_: RawDirect3DDevice, message: Self::Flags) -> Result<Self, Self::Error> {
         println!("Got The Flag: {message}");
 
         let encoder = VideoEncoder::new(

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -10,10 +10,8 @@ use std::{
 use clap::Parser;
 
 use windows_capture::{
-    capture::GraphicsCaptureApiHandler,
-    encoder::{
-        AudioSettingsBuilder, ContainerSettingsBuilder, VideoEncoder, VideoSettingsBuilder,
-    },
+    capture::{GraphicsCaptureApiHandler, RawDirect3DDevice},
+    encoder::{AudioSettingsBuilder, ContainerSettingsBuilder, VideoEncoder, VideoSettingsBuilder},
     frame::Frame,
     graphics_capture_api::InternalCaptureControl,
     monitor::Monitor,
@@ -55,7 +53,7 @@ impl GraphicsCaptureApiHandler for Capture {
     type Error = Box<dyn std::error::Error + Send + Sync>;
 
     // Function that will be called to create the struct. The flags can be passed from settings.
-    fn new(settings: Self::Flags) -> Result<Self, Self::Error> {
+    fn new(_: RawDirect3DDevice, settings: Self::Flags) -> Result<Self, Self::Error> {
         println!("Capture started.");
 
         let video_settings = VideoSettingsBuilder::new(settings.width, settings.height)
@@ -226,8 +224,7 @@ fn main() {
 
     if let Some(window_name) = cli.window_name {
         // May use Window::foreground() instead
-        let capture_item =
-            Window::from_contains_name(&window_name).expect("Window not found!");
+        let capture_item = Window::from_contains_name(&window_name).expect("Window not found!");
 
         // Automatically detect window's width and height
         let rect = capture_item.rect().expect("Failed to get window rect");
@@ -249,12 +246,7 @@ fn main() {
         );
         println!("Window size: {}x{}", width, height);
 
-        start_capture(
-            capture_item,
-            cursor_capture,
-            draw_border,
-            capture_settings,
-        );
+        start_capture(capture_item, cursor_capture, draw_border, capture_settings);
     } else if let Some(index) = cli.monitor_index {
         // May use Monitor::primary() instead
         let capture_item =
@@ -276,12 +268,7 @@ fn main() {
         println!("Monitor index: {}", index);
         println!("Monitor size: {}x{}", width, height);
 
-        start_capture(
-            capture_item,
-            cursor_capture,
-            draw_border,
-            capture_settings,
-        );
+        start_capture(capture_item, cursor_capture, draw_border, capture_settings);
     } else {
         eprintln!("Either --window-name or --monitor-index must be provided");
         std::process::exit(1);

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -991,7 +991,9 @@ impl VideoEncoder {
         };
 
         self.frame_sender.send(Some((
-            VideoEncoderSource::DirectX(SendDirectX::new(unsafe { frame.as_raw_surface() })),
+            VideoEncoderSource::DirectX(SendDirectX::new(unsafe {
+                frame.as_raw_surface().clone()
+            })),
             timespan,
         )))?;
 
@@ -1051,7 +1053,9 @@ impl VideoEncoder {
         };
 
         self.frame_sender.send(Some((
-            VideoEncoderSource::DirectX(SendDirectX::new(unsafe { frame.as_raw_surface() })),
+            VideoEncoderSource::DirectX(SendDirectX::new(unsafe {
+                frame.as_raw_surface().clone()
+            })),
             timespan,
         )))?;
 

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -168,8 +168,8 @@ impl<'a> Frame<'a> {
     /// This method is unsafe because it returns a raw pointer to the IDirect3DSurface.
     #[must_use]
     #[inline]
-    pub unsafe fn as_raw_surface(&self) -> IDirect3DSurface {
-        self.frame_surface.clone()
+    pub unsafe fn as_raw_surface(&self) -> &IDirect3DSurface {
+        &self.frame_surface
     }
 
     /// Get the raw texture of the frame.
@@ -178,7 +178,17 @@ impl<'a> Frame<'a> {
     ///
     /// The ID3D11Texture2D representing the raw texture of the frame.
     #[inline]
-    pub fn texture(&self) -> Result<ID3D11Texture2D, Error> {
+    pub unsafe fn as_raw_texture(&self) -> &ID3D11Texture2D {
+        &self.frame_texture
+    }
+
+    /// Get the frame buffer.
+    ///
+    /// # Returns
+    ///
+    /// The FrameBuffer containing the frame data.
+    #[inline]
+    pub fn buffer(&mut self) -> Result<FrameBuffer, Error> {
         // Texture Settings
         let texture_desc = D3D11_TEXTURE2D_DESC {
             Width: self.width,
@@ -192,7 +202,7 @@ impl<'a> Frame<'a> {
             },
             Usage: D3D11_USAGE_STAGING,
             BindFlags: 0,
-            CPUAccessFlags: D3D11_CPU_ACCESS_READ.0 as u32 | D3D11_CPU_ACCESS_WRITE.0 as u32,
+            CPUAccessFlags: D3D11_CPU_ACCESS_READ.0 as u32,
             MiscFlags: 0,
         };
 
@@ -209,18 +219,6 @@ impl<'a> Frame<'a> {
         unsafe {
             self.context.CopyResource(&texture, &self.frame_texture);
         };
-
-        Ok(texture)
-    }
-
-    /// Get the frame buffer.
-    ///
-    /// # Returns
-    ///
-    /// The FrameBuffer containing the frame data.
-    #[inline]
-    pub fn buffer(&mut self) -> Result<FrameBuffer, Error> {
-        let texture = self.texture()?;
 
         // Map the texture to enable CPU access
         let mut mapped_resource = D3D11_MAPPED_SUBRESOURCE::default();

--- a/src/graphics_capture_api.rs
+++ b/src/graphics_capture_api.rs
@@ -23,7 +23,7 @@ use windows::{
 
 use crate::{
     capture::GraphicsCaptureApiHandler,
-    d3d11::{self, create_d3d_device, create_direct3d_device, SendDirectX},
+    d3d11::{self, create_direct3d_device, SendDirectX},
     frame::Frame,
     settings::{ColorFormat, CursorCaptureSettings, DrawBorderSettings},
 };
@@ -117,6 +117,8 @@ impl GraphicsCaptureApi {
         T: GraphicsCaptureApiHandler<Error = E> + Send + 'static,
         E: Send + Sync + 'static,
     >(
+        d3d_device: ID3D11Device,
+        d3d_device_context: ID3D11DeviceContext,
         item: GraphicsCaptureItem,
         callback: Arc<Mutex<T>>,
         cursor_capture: CursorCaptureSettings,
@@ -141,7 +143,6 @@ impl GraphicsCaptureApi {
         }
 
         // Create DirectX devices
-        let (d3d_device, d3d_device_context) = create_d3d_device()?;
         let direct3d_device = create_direct3d_device(&d3d_device)?;
 
         let pixel_format = DirectXPixelFormat(color_format as i32);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@
 //! };
 //!
 //! use windows_capture::{
-//!     capture::GraphicsCaptureApiHandler,
+//!     capture::{GraphicsCaptureApiHandler, RawDirect3DDevice},
 //!     encoder::{AudioSettingsBuilder, ContainerSettingsBuilder, VideoEncoder, VideoSettingsBuilder},
 //!     frame::Frame,
 //!     graphics_capture_api::InternalCaptureControl,
@@ -63,7 +63,7 @@
 //!     type Error = Box<dyn std::error::Error + Send + Sync>;
 //!
 //!     // Function that will be called to create the struct. The flags can be passed from settings.
-//!     fn new(message: Self::Flags) -> Result<Self, Self::Error> {
+//!     fn new(_: RawDirect3DDevice, message: Self::Flags) -> Result<Self, Self::Error> {
 //!         println!("Got The Flag: {message}");
 //!
 //!         let encoder = VideoEncoder::new(

--- a/windows-capture-python/src/lib.rs
+++ b/windows-capture-python/src/lib.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use ::windows_capture::{
     capture::{
         CaptureControl, CaptureControlError, GraphicsCaptureApiError, GraphicsCaptureApiHandler,
+        RawDirect3DDevice,
     },
     frame::{self, Frame},
     graphics_capture_api::InternalCaptureControl,
@@ -368,7 +369,10 @@ impl GraphicsCaptureApiHandler for InnerNativeWindowsCapture {
     type Error = InnerNativeWindowsCaptureError;
 
     #[inline]
-    fn new((on_frame_arrived_callback, on_closed): Self::Flags) -> Result<Self, Self::Error> {
+    fn new(
+        _: RawDirect3DDevice,
+        (on_frame_arrived_callback, on_closed): Self::Flags,
+    ) -> Result<Self, Self::Error> {
         Ok(Self {
             on_frame_arrived_callback,
             on_closed,


### PR DESCRIPTION
## Zero copy texture

First, get `ID3D11Texture2D` directly via `Frame`, without making a copy internally, and just return the texture in the current frame.

https://github.com/mycrl/windows-capture/blob/main/src/frame.rs#L181
```rust
pub unsafe fn as_raw_texture(&self) -> &ID3D11Texture2D {
    &self.frame_texture
}
``` 

Then, it's not really necessary to clone once to get surface and texture, although `ID3D11Texture2D` and `IDirect3DSurface` are actually pointers internally, and it doesn't really matter if you return a reference or not, I think it's good to return a reference to clarify the semantics, and to indicate that surface and texture are only available during the current frame's lifetime.

Also I removed the CPU write flag for textures, because for the usage scenario here, there is no need to make the CPU writable to the texture, only readable, and keeping only the read flag makes it easier for the Direct3D underlayer to deal with resource mutexes and improve performance, Because if it is possible to write, the underlayer needs to think more about resource contention and introduce unnecessary locks or similar mechanism.

https://github.com/mycrl/windows-capture/blob/main/src/frame.rs#L205
```rust
CPUAccessFlags: D3D11_CPU_ACCESS_READ.0 as u32
```

## External access to Direct3D devices and contexts

Then there's the second big change, adding a `RawDirect3DDevice` parameter to the `new` method of the `GraphicsCaptureApiHandler` trait.

https://github.com/mycrl/windows-capture/blob/main/src/capture.rs#L516
```rust
fn new(device: RawDirect3DDevice, flags: Self::Flags) -> Result<Self, Self::Error>;
```

First, let me explain why this parameter is needed. In direct3d11, devices and contexts are independent, if windows-capture doesn't expose its own devices and contexts, then external parties can't use your textures or have a hard time using your textures, of course, external parties can use the software buffers, but this goes against the zero-copy and performance-first principles.
For example, if you need to use the texture directly for some post-processing, scaling and texture format conversion needs, the only way to do this is to keep creating cross-device shared resource handles for each frame. At the same time, creating shared resource handles for each frame is also a high overhead operation (acceptable when both sides are using dx11).
Therefore, it is necessary to perform this operation in windows-capture's own device and context, because the library aims for high performance and you need to enable users to use your library in a high performance way.

