### PR TITLE
bug fix: Add CPU write access flag

### DIFF
--- a/src/frame.rs
+++ b/src/frame.rs
@@ -205,7 +205,7 @@ impl<'a> Frame<'a> {
             },
             Usage: D3D11_USAGE_STAGING,
             BindFlags: 0,
-            CPUAccessFlags: D3D11_CPU_ACCESS_READ.0 as u32,
+            CPUAccessFlags: D3D11_CPU_ACCESS_READ.0 as u32 | D3D11_CPU_ACCESS_WRITE.0 as u32,
             MiscFlags: 0,
         };
 


### PR DESCRIPTION
In the last commit #90, I just removed the write access flag from the texture, but didn't change everything involving this texture to read-only, which caused a lot of problems, so instead of obsessing about whether or not the texture is writable, just add `D3D11_CPU_ACCESS_WRITE` to it to quickly fix the problems caused by the previous bug.