### PR TITLE
Proposal to Integrate Client Area Capture Natively

### DIFF
--- a/windows-capture-python/README-Python.md
+++ b/windows-capture-python/README-Python.md
@@ -125,8 +125,8 @@ def on_frame_arrived(frame: Frame, capture_control: InternalCaptureControl):
 
     # Remove the top bar from the frame
     window_rect = get_window_rect(WINDOW_TITLE, client=True)
-    from_top_bar = frame.height - window_rect.height
-    frame = frame.crop(0, from_top_bar, window_rect.width, window_rect.height)
+    top_bar_size = frame.height - window_rect.height
+    frame = frame.crop(0, top_bar_size, window_rect.width, window_rect.height + top_bar_size)
 
     # Save The Frame As An Image To The Specified Path
     frame.save_as_image("image.png")

--- a/windows-capture-python/README.md
+++ b/windows-capture-python/README.md
@@ -125,8 +125,8 @@ def on_frame_arrived(frame: Frame, capture_control: InternalCaptureControl):
 
     # Remove the top bar from the frame
     window_rect = get_window_rect(WINDOW_TITLE, client=True)
-    from_top_bar = frame.height - window_rect.height
-    frame = frame.crop(0, from_top_bar, window_rect.width, window_rect.height)
+    top_bar_size = frame.height - window_rect.height
+    frame = frame.crop(0, top_bar_size, window_rect.width, window_rect.height + top_bar_size)
 
     # Save The Frame As An Image To The Specified Path
     frame.save_as_image("image.png")


### PR DESCRIPTION
### Summary

This PR demonstrates capturing a window's client area (excluding non-client regions like the title bar) using `win32gui` to calculate offsets and manually crop frames. While functional, integrating this natively would simplify a common use case and reduce external dependencies.

---

### Key Details

- The example retrieves the client area dimensions via `get_window_rect` and crops frames to exclude window decorations.
- Users often need to capture **only the client area** (e.g., for clean application screenshots or UI automation).
- Manual offset calculations introduce boilerplate and potential inaccuracies (e.g., assuming static title bar heights or handling DPI scaling).

---

### Suggested Parameter Names

To streamline this, consider adding one of the following parameters to `WindowsCapture`:

1. **Option 1:** `include_top_bar`
```python
capture = WindowsCapture(
    window_name="Notepad",
    include_top_bar=False  # Default: True (retain decorations)
)
```
* **Behavior:** When `False`, auto-crops the top bar and other non-client regions.
* **Advantages**: Explicitly targets the title bar, a common user concern.
2. **Option 2:** capture_client_area
```python
capture = WindowsCapture(
    window_name="Notepad",
    capture_client_area=True  # Default: False (capture full window)
)
```
* **Behavior:** When `True`, captures only the client area (matches `GetClientRect` semantics).
* **Advantages:** Aligns with Windows API terminology and covers all non-client regions (borders, menus, etc.).

---

**Benefits of Native Integration**

1. **Simplifies Code:** Removes the need for `win32gui` and manual cropping logic.
2. **Improves Accuracy:** Handles dynamic window resizing and DPI scaling internally.
3. **Performance:** Could leverage native APIs (e.g., `GetClientRect`) during capture setup rather than per-frame calculations.
4. **Consistency:** Aligns with the library’s "Easy To Use" philosophy by abstracting a frequent use case.