### PR TITLE
Add support for `IncludeSecondaryWindows`

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -9,7 +9,9 @@ use windows_capture::{
     frame::Frame,
     graphics_capture_api::InternalCaptureControl,
     monitor::Monitor,
-    settings::{ColorFormat, CursorCaptureSettings, DrawBorderSettings, Settings},
+    settings::{
+        ColorFormat, CursorCaptureSettings, DrawBorderSettings, SecondaryWindowSettings, Settings,
+    },
 };
 
 // Handles capture events.
@@ -24,10 +26,12 @@ impl GraphicsCaptureApiHandler for Capture {
     // The type of flags used to get the values from the settings.
     type Flags = String;
 
-    // The type of error that can be returned from `CaptureControl` and `start` functions.
+    // The type of error that can be returned from `CaptureControl` and `start`
+    // functions.
     type Error = Box<dyn std::error::Error + Send + Sync>;
 
-    // Function that will be called to create a new instance. The flags can be passed from settings.
+    // Function that will be called to create a new instance. The flags can be
+    // passed from settings.
     fn new(ctx: Context<Self::Flags>) -> Result<Self, Self::Error> {
         println!("Created with Flags: {}", ctx.flags);
 
@@ -59,10 +63,10 @@ impl GraphicsCaptureApiHandler for Capture {
         // Send the frame to the video encoder
         self.encoder.as_mut().unwrap().send_frame(frame)?;
 
-        // Note: The frame has other uses too, for example, you can save a single frame to a file, like this:
-        // frame.save_as_image("frame.png", ImageFormat::Png)?;
-        // Or get the raw data like this so you have full control:
-        // let data = frame.buffer()?;
+        // Note: The frame has other uses too, for example, you can save a single frame
+        // to a file, like this: frame.save_as_image("frame.png",
+        // ImageFormat::Png)?; Or get the raw data like this so you have full
+        // control: let data = frame.buffer()?;
 
         // Stop the capture after 6 seconds
         if self.start.elapsed().as_secs() >= 6 {
@@ -97,9 +101,12 @@ fn main() {
         CursorCaptureSettings::Default,
         // Draw border settings
         DrawBorderSettings::Default,
+        // Secondary window settings,
+        SecondaryWindowSettings::Default,
         // The desired color format for the captured frame.
         ColorFormat::Rgba8,
-        // Additional flags for the capture settings that will be passed to user defined `new` function.
+        // Additional flags for the capture settings that will be passed to user defined `new`
+        // function.
         "Yea this works".to_string(),
     );
 

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -67,7 +67,8 @@ impl<T: GraphicsCaptureApiHandler + Send + 'static, E> CaptureControl<T, E> {
     ///
     /// * `thread_handle` - The join handle for the capture thread.
     /// * `halt_handle` - The atomic boolean used to pause the capture thread.
-    /// * `callback` - The mutex-protected callback struct used to call struct methods directly.
+    /// * `callback` - The mutex-protected callback struct used to call struct
+    ///   methods directly.
     ///
     /// # Returns
     ///
@@ -237,7 +238,8 @@ pub trait GraphicsCaptureApiHandler: Sized {
     /// The type of flags used to get the values from the settings.
     type Flags;
 
-    /// The type of error that can occur during capture, the error will be returned from `CaptureControl` and `start` functions.
+    /// The type of error that can occur during capture, the error will be
+    /// returned from `CaptureControl` and `start` functions.
     type Error: Send + Sync;
 
     /// Starts the capture and takes control of the current thread.
@@ -248,7 +250,8 @@ pub trait GraphicsCaptureApiHandler: Sized {
     ///
     /// # Returns
     ///
-    /// Returns `Ok(())` if the capture was successful, otherwise returns an error of type `GraphicsCaptureApiError`.
+    /// Returns `Ok(())` if the capture was successful, otherwise returns an
+    /// error of type `GraphicsCaptureApiError`.
     #[inline]
     fn start<T: TryInto<GraphicsCaptureItem> + Send + 'static>(
         settings: Settings<Self::Flags, T>,
@@ -320,6 +323,7 @@ pub trait GraphicsCaptureApiHandler: Sized {
             callback,
             settings.cursor_capture,
             settings.draw_border,
+            settings.secondary_windows,
             settings.color_format,
             window,
             thread_id,
@@ -385,7 +389,8 @@ pub trait GraphicsCaptureApiHandler: Sized {
     ///
     /// # Returns
     ///
-    /// Returns `Ok(CaptureControl)` if the capture was successful, otherwise returns an error of type `GraphicsCaptureApiError`.
+    /// Returns `Ok(CaptureControl)` if the capture was successful, otherwise
+    /// returns an error of type `GraphicsCaptureApiError`.
     #[inline]
     fn start_free_threaded<T: TryInto<GraphicsCaptureItem> + Send + 'static>(
         settings: Settings<Self::Flags, T>,
@@ -463,6 +468,7 @@ pub trait GraphicsCaptureApiHandler: Sized {
                     callback.clone(),
                     settings.cursor_capture,
                     settings.draw_border,
+                    settings.secondary_windows,
                     settings.color_format,
                     window,
                     thread_id,
@@ -552,7 +558,8 @@ pub trait GraphicsCaptureApiHandler: Sized {
         Ok(CaptureControl::new(thread_handle, halt_handle, callback))
     }
 
-    /// Function that will be called to create the struct. The flags can be passed from settings.
+    /// Function that will be called to create the struct. The flags can be
+    /// passed from settings.
     ///
     /// # Arguments
     ///
@@ -560,7 +567,8 @@ pub trait GraphicsCaptureApiHandler: Sized {
     ///
     /// # Returns
     ///
-    /// Returns `Ok(Self)` if the struct creation was successful, otherwise returns an error of type `Self::Error`.
+    /// Returns `Ok(Self)` if the struct creation was successful, otherwise
+    /// returns an error of type `Self::Error`.
     fn new(ctx: Context<Self::Flags>) -> Result<Self, Self::Error>;
 
     /// Called every time a new frame is available.
@@ -572,7 +580,8 @@ pub trait GraphicsCaptureApiHandler: Sized {
     ///
     /// # Returns
     ///
-    /// Returns `Ok(())` if the frame processing was successful, otherwise returns an error of type `Self::Error`.
+    /// Returns `Ok(())` if the frame processing was successful, otherwise
+    /// returns an error of type `Self::Error`.
     fn on_frame_arrived(
         &mut self,
         frame: &mut Frame,
@@ -583,7 +592,8 @@ pub trait GraphicsCaptureApiHandler: Sized {
     ///
     /// # Returns
     ///
-    /// Returns `Ok(())` if the handler execution was successful, otherwise returns an error of type `Self::Error`.
+    /// Returns `Ok(())` if the handler execution was successful, otherwise
+    /// returns an error of type `Self::Error`.
     #[inline]
     fn on_closed(&mut self) -> Result<(), Self::Error> {
         Ok(())

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -32,6 +32,13 @@ pub enum DrawBorderSettings {
     WithoutBorder,
 }
 
+#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+pub enum SecondaryWindowSettings {
+    Default,
+    Include,
+    Exclude,
+}
+
 #[derive(Eq, PartialEq, Clone, Debug)]
 /// Represents the settings for screen capturing.
 pub struct Settings<Flags, T: TryInto<GraphicsCaptureItem>> {
@@ -41,6 +48,8 @@ pub struct Settings<Flags, T: TryInto<GraphicsCaptureItem>> {
     pub(crate) cursor_capture: CursorCaptureSettings,
     /// Specifies whether to draw a border around the captured region.
     pub(crate) draw_border: DrawBorderSettings,
+    /// Specifies whether to include secondary windows in the capture.
+    pub(crate) secondary_windows: SecondaryWindowSettings,
     /// The color format for the captured graphics.
     pub(crate) color_format: ColorFormat,
     /// Additional flags for capturing graphics.
@@ -57,15 +66,18 @@ where
     ///
     /// * `item` - The graphics capture item.
     /// * `capture_cursor` - Whether to capture the cursor or not.
-    /// * `draw_border` - Whether to draw a border around the captured region or not.
+    /// * `draw_border` - Whether to draw a border around the captured region or
+    ///   not.
     /// * `color_format` - The desired color format for the captured frame.
-    /// * `flags` - Additional flags for the capture settings that will be passed to user defined `new` function.
+    /// * `flags` - Additional flags for the capture settings that will be
+    ///   passed to user defined `new` function.
     #[must_use]
     #[inline]
     pub const fn new(
         item: T,
         cursor_capture: CursorCaptureSettings,
         draw_border: DrawBorderSettings,
+        secondary_windows: SecondaryWindowSettings,
         color_format: ColorFormat,
         flags: Flags,
     ) -> Self {
@@ -73,6 +85,7 @@ where
             item,
             cursor_capture,
             draw_border,
+            secondary_windows,
             color_format,
             flags,
         }
@@ -109,6 +122,17 @@ where
     #[inline]
     pub const fn draw_border(&self) -> DrawBorderSettings {
         self.draw_border
+    }
+
+    /// Get the secondary window settings
+    ///
+    /// # Returns
+    ///
+    /// The secondary window settings
+    #[must_use]
+    #[inline]
+    pub const fn secondary_windows(&self) -> SecondaryWindowSettings {
+        self.secondary_windows
     }
 
     /// Get the color format


### PR DESCRIPTION
This adds support for the [`IncludeSecondaryWindows` property](https://learn.microsoft.com/en-us/uwp/api/windows.graphics.capture.graphicscapturesession.includesecondarywindows?view=winrt-26100#windows-graphics-capture-graphicscapturesession-includesecondarywindows)

this is a breaking change as it adds a new argument/field to graphics capture settings and such.

also some minor formatting stuff because rustfmt ran when I saved in vscode.