### PR TITLE
Accept `&Frame` instead of `&mut Frame` in `VideoEncoder::send_frame`

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -938,14 +938,14 @@ impl VideoEncoder {
     ///
     /// # Arguments
     ///
-    /// * `frame` - A mutable reference to the `Frame` to be encoded.
+    /// * `frame` - A reference to the `Frame` to be encoded.
     ///
     /// # Returns
     ///
     /// Returns `Ok(())` if the frame is successfully sent for encoding, or a `VideoEncoderError`
     /// if an error occurs.
     #[inline]
-    pub fn send_frame(&mut self, frame: &mut Frame) -> Result<(), VideoEncoderError> {
+    pub fn send_frame(&mut self, frame: &Frame) -> Result<(), VideoEncoderError> {
         if self.is_video_disabled {
             return Err(VideoEncoderError::VideoDisabled);
         }


### PR DESCRIPTION
Maybe im missing something, but looks like there is no need for `Frame` to be mut in `send_frame`.
@NiiightmareXD 

In my specific use case, I send `Arc<Frame>` to multiple consumers, and some of them need to write the frame 
using an encoder, but they can't obtain a mut ref to an Arc value. Also, Frame does not implement clone.

Thanks for the support ❤️ 