### PR TITLE
Add support for compiling for 32-bit windows 🧟‍♂️

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,21 +2,26 @@ name: Rust
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   build:
-
     runs-on: windows-latest
 
+    strategy:
+      matrix:
+        target: [x86_64-pc-windows-msvc, i686-pc-windows-msvc]
+
     steps:
-    - uses: actions/checkout@v3
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+      - uses: actions/checkout@v4
+      - name: Add target
+        run: rustup target add ${{ matrix.target }}
+      - name: Build
+        run: cargo build --verbose --target ${{ matrix.target }}
+      - name: Run tests
+        run: cargo test --verbose --target ${{ matrix.target }}

--- a/src/window.rs
+++ b/src/window.rs
@@ -266,8 +266,8 @@ impl Window {
         let mut rect = RECT::default();
         let result = unsafe { GetClientRect(self.window, &mut rect) };
         if result.is_ok() {
-            let styles = unsafe { GetWindowLongPtrW(self.window, GWL_STYLE) };
-            let ex_styles = unsafe { GetWindowLongPtrW(self.window, GWL_EXSTYLE) };
+            let styles = unsafe { GetWindowLongPtrW(self.window, GWL_STYLE) } as isize;
+            let ex_styles = unsafe { GetWindowLongPtrW(self.window, GWL_EXSTYLE) } as isize;
 
             if (ex_styles & isize::try_from(WS_EX_TOOLWINDOW.0).unwrap()) != 0 {
                 return false;


### PR DESCRIPTION
It looks like `GetWindowLongPtrW()` was returning `i32` instead of `isize` when compiling to the `i686-pc-windows-msvc` target. Fixed this and added a 32-bit compilation job to the workflow.