### PR TITLE
feat(python): add window_hwnd parameter for HWND-based capture

### DIFF
--- a/windows-capture-python/windows_capture/__init__.py
+++ b/windows-capture-python/windows_capture/__init__.py
@@ -179,6 +179,7 @@ class WindowsCapture:
         dirty_region: Optional[bool] = None,
         monitor_index: Optional[int] = None,
         window_name: Optional[str] = None,
+        window_hwnd: Optional[int] = None,
     ) -> None:
         """
         Constructs All The Necessary Attributes For The WindowsCapture Object
@@ -200,9 +201,13 @@ class WindowsCapture:
             monitor_index : int
                 Index Of The Monitor To Capture
             window_name : str
-                Name Of The Window To Capture
+                Name Of The Window To Capture (substring match)
+            window_hwnd : int
+                Window Handle (HWND) To Capture - more reliable than window_name
+                for windows with dynamic titles
         """
-        if window_name is not None:
+        # Clear monitor_index if a window target is specified
+        if window_name is not None or window_hwnd is not None:
             monitor_index = None
 
         self.frame_handler: Optional[types.FunctionType] = None
@@ -217,6 +222,7 @@ class WindowsCapture:
             dirty_region,
             monitor_index,
             window_name,
+            window_hwnd,
         )
 
     def start(self) -> None:


### PR DESCRIPTION
## Summary

Add support for capturing windows by their native HWND handle instead of window name in the Python bindings.

This is more reliable for windows with dynamic titles (e.g., RetroArch showing FPS in title bar, or games showing scene names).

## Changes

- Added `window_hwnd: Option<isize>` field to `NativeWindowsCapture` struct
- Updated constructor to accept `window_hwnd` parameter
- Updated validation to ensure only one of `monitor_index`, `window_name`, or `window_hwnd` is specified
- Updated `start()` and `start_free_threaded()` methods to use `Window::from_raw_hwnd()` when `window_hwnd` is provided
- Updated Python `WindowsCapture` class to expose the new parameter

## Usage

```python
from windows_capture import WindowsCapture

# Capture by HWND (most reliable for dynamic window titles)
capture = WindowsCapture(window_hwnd=0x12345)

# Existing methods still work
capture = WindowsCapture(window_name="Notepad")
capture = WindowsCapture(monitor_index=1)
```

## Context

This addresses issue #131 where users reported that `window_name` matching was unreliable for windows with dynamic titles. The Rust library already has `Window::from_raw_hwnd()` - this PR exposes that functionality in the Python bindings.