### PR TITLE
feat(example): add stream_capture example and update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,5 +82,9 @@ doc-scrape-examples = false
 name = "cli"
 doc-scrape-examples = false
 
+[[example]]
+name = "stream_capture"
+doc-scrape-examples = false
+
 [workspace]
 members = ["windows-capture-python"]

--- a/README.md
+++ b/README.md
@@ -173,6 +173,124 @@ fn main() {
 }
 ```
 
+## Stream-based encoding example
+
+Instead of writing directly to a file, you can encode into an in-memory stream using `VideoEncoder::new_from_stream`. This is useful when you need to send the encoded video over a network, pipe it to another process, or process it further before saving.
+
+```rust
+use std::io::{self, Write};
+use std::time::Instant;
+
+use windows::Storage::Streams::InMemoryRandomAccessStream;
+use windows::core::Interface;
+use windows_capture::capture::{Context, GraphicsCaptureApiHandler};
+use windows_capture::encoder::{
+    AudioSettingsBuilder, ContainerSettingsBuilder, VideoEncoder, VideoSettingsBuilder,
+};
+use windows_capture::frame::Frame;
+use windows_capture::graphics_capture_api::InternalCaptureControl;
+use windows_capture::graphics_capture_picker::GraphicsCapturePicker;
+use windows_capture::settings::{
+    ColorFormat, CursorCaptureSettings, DirtyRegionSettings, DrawBorderSettings,
+    MinimumUpdateIntervalSettings, SecondaryWindowSettings, Settings,
+};
+
+struct StreamCapture {
+    encoder: Option<VideoEncoder>,
+    stream: InMemoryRandomAccessStream,
+    start: Instant,
+}
+
+impl GraphicsCaptureApiHandler for StreamCapture {
+    type Flags = (i32, i32);
+    type Error = Box<dyn std::error::Error + Send + Sync>;
+
+    fn new(ctx: Context<Self::Flags>) -> Result<Self, Self::Error> {
+        // Create an in-memory stream that the encoder will write into.
+        let stream = InMemoryRandomAccessStream::new()?;
+
+        let encoder = VideoEncoder::new_from_stream(
+            VideoSettingsBuilder::new(ctx.flags.0 as u32, ctx.flags.1 as u32),
+            AudioSettingsBuilder::default().disabled(true),
+            ContainerSettingsBuilder::default(),
+            stream.cast()?,
+        )?;
+
+        Ok(Self {
+            encoder: Some(encoder),
+            stream,
+            start: Instant::now(),
+        })
+    }
+
+    fn on_frame_arrived(
+        &mut self,
+        frame: &mut Frame,
+        capture_control: InternalCaptureControl,
+    ) -> Result<(), Self::Error> {
+        print!(
+            "\rStreaming for: {} seconds | Buffer size: {} bytes",
+            self.start.elapsed().as_secs(),
+            self.stream.Size()?
+        );
+        io::stdout().flush()?;
+
+        self.encoder.as_mut().unwrap().send_frame(frame)?;
+
+        if self.start.elapsed().as_secs() >= 6 {
+            self.encoder.take().unwrap().finish()?;
+
+            let size = self.stream.Size()?;
+            println!("\nCapture finished. Stream contains {size} bytes.");
+
+            // Read the encoded bytes from the in-memory stream.
+            let reader = windows::Storage::Streams::DataReader::CreateDataReader(
+                &self.stream.GetInputStreamAt(0)?,
+            )?;
+            reader.LoadAsync(size as u32)?.join()?;
+
+            let mut bytes = vec![0u8; size as usize];
+            reader.ReadBytes(&mut bytes)?;
+            std::fs::write("stream_output.mp4", &bytes)?;
+
+            println!("Saved stream to stream_output.mp4");
+            capture_control.stop();
+        }
+
+        Ok(())
+    }
+
+    fn on_closed(&mut self) -> Result<(), Self::Error> {
+        println!("Capture session ended");
+        Ok(())
+    }
+}
+
+fn main() {
+    let item = GraphicsCapturePicker::pick_item().expect("Failed to pick item");
+
+    let Some(item) = item else {
+        println!("No item selected");
+        return;
+    };
+
+    let size = item.size().expect("Failed to get item size");
+
+    let settings = Settings::new(
+        item,
+        CursorCaptureSettings::Default,
+        DrawBorderSettings::Default,
+        SecondaryWindowSettings::Default,
+        MinimumUpdateIntervalSettings::Default,
+        DirtyRegionSettings::Default,
+        ColorFormat::Rgba8,
+        size,
+    );
+
+    StreamCapture::start(settings).expect("Stream capture failed");
+}
+```
+
 ## DXGI Desktop Duplication example
 
 ```rust

--- a/examples/graphics_capture.rs
+++ b/examples/graphics_capture.rs
@@ -1,6 +1,7 @@
 use std::io::{self, Write};
 use std::time::Instant;
 
+use windows::Storage::Streams::IRandomAccessStream;
 use windows_capture::capture::{Context, GraphicsCaptureApiHandler};
 use windows_capture::encoder::{AudioSettingsBuilder, ContainerSettingsBuilder, VideoEncoder, VideoSettingsBuilder};
 use windows_capture::frame::Frame;

--- a/examples/stream_capture.rs
+++ b/examples/stream_capture.rs
@@ -1,0 +1,118 @@
+use std::io::{self, Write};
+use std::time::Instant;
+
+use windows::Storage::Streams::InMemoryRandomAccessStream;
+use windows::core::Interface;
+use windows_capture::capture::{Context, GraphicsCaptureApiHandler};
+use windows_capture::encoder::{
+    AudioSettingsBuilder, ContainerSettingsBuilder, VideoEncoder, VideoSettingsBuilder,
+};
+use windows_capture::frame::Frame;
+use windows_capture::graphics_capture_api::InternalCaptureControl;
+use windows_capture::graphics_capture_picker::GraphicsCapturePicker;
+use windows_capture::settings::{
+    ColorFormat, CursorCaptureSettings, DirtyRegionSettings, DrawBorderSettings,
+    MinimumUpdateIntervalSettings, SecondaryWindowSettings, Settings,
+};
+
+struct StreamCapture {
+    encoder: Option<VideoEncoder>,
+    stream: InMemoryRandomAccessStream,
+    start: Instant,
+}
+
+impl GraphicsCaptureApiHandler for StreamCapture {
+    type Flags = (i32, i32);
+    type Error = Box<dyn std::error::Error + Send + Sync>;
+
+    fn new(ctx: Context<Self::Flags>) -> Result<Self, Self::Error> {
+        // Create an in-memory stream that the encoder will write into.
+        // This is useful for scenarios where you want to process the encoded
+        // video in memory (e.g., sending it over a network, piping to another
+        // process, or performing further transformations) instead of writing
+        // directly to a file.
+        let stream = InMemoryRandomAccessStream::new()?;
+
+        let encoder = VideoEncoder::new_from_stream(
+            VideoSettingsBuilder::new(ctx.flags.0 as u32, ctx.flags.1 as u32),
+            AudioSettingsBuilder::default().disabled(true),
+            ContainerSettingsBuilder::default(),
+            stream.cast()?,
+        )?;
+
+        Ok(Self {
+            encoder: Some(encoder),
+            stream,
+            start: Instant::now(),
+        })
+    }
+
+    fn on_frame_arrived(
+        &mut self,
+        frame: &mut Frame,
+        capture_control: InternalCaptureControl,
+    ) -> Result<(), Self::Error> {
+        print!(
+            "\rStreaming for: {} seconds | Buffer size: {} bytes",
+            self.start.elapsed().as_secs(),
+            self.stream.Size()?
+        );
+        io::stdout().flush()?;
+
+        self.encoder.as_mut().unwrap().send_frame(frame)?;
+
+        // Stop after 6 seconds and dump the in-memory buffer to a file to prove
+        // the stream-based encoder works. In a real application you would read
+        // from the stream continuously and forward the bytes elsewhere.
+        if self.start.elapsed().as_secs() >= 6 {
+            self.encoder.take().unwrap().finish()?;
+
+            let size = self.stream.Size()?;
+            println!("\nCapture finished. Stream contains {size} bytes.");
+
+            // Write the in-memory stream to a file as a demonstration.
+            let reader =
+                windows::Storage::Streams::DataReader::CreateDataReader(&self.stream.GetInputStreamAt(0)?)?;
+            reader.LoadAsync(size as u32)?.join()?;
+
+            let mut bytes = vec![0u8; size as usize];
+            reader.ReadBytes(&mut bytes)?;
+            std::fs::write("stream_output.mp4", &bytes)?;
+
+            println!("Saved stream to stream_output.mp4");
+
+            capture_control.stop();
+        }
+
+        Ok(())
+    }
+
+    fn on_closed(&mut self) -> Result<(), Self::Error> {
+        println!("Capture session ended");
+        Ok(())
+    }
+}
+
+fn main() {
+    let item = GraphicsCapturePicker::pick_item().expect("Failed to pick item");
+
+    let Some(item) = item else {
+        println!("No item selected");
+        return;
+    };
+
+    let size = item.size().expect("Failed to get item size");
+
+    let settings = Settings::new(
+        item,
+        CursorCaptureSettings::Default,
+        DrawBorderSettings::Default,
+        SecondaryWindowSettings::Default,
+        MinimumUpdateIntervalSettings::Default,
+        DirtyRegionSettings::Default,
+        ColorFormat::Rgba8,
+        size,
+    );
+
+    StreamCapture::start(settings).expect("Stream capture failed");
+}

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -981,6 +981,29 @@ impl VideoEncoder {
     }
 
     /// Constructs a new `VideoEncoder` that writes to the given stream.
+    ///
+    /// Unlike [`VideoEncoder::new`], which writes directly to a file, this constructor writes
+    /// encoded output into any [`IRandomAccessStream`]. Use [`InMemoryRandomAccessStream`] to
+    /// keep the encoded video in memory (e.g., for network streaming or further processing).
+    ///
+    /// # Example
+    /// ```no_run
+    /// use windows::Storage::Streams::InMemoryRandomAccessStream;
+    /// use windows::core::Interface;
+    /// use windows_capture::encoder::{
+    ///     AudioSettingsBuilder, ContainerSettingsBuilder, VideoEncoder, VideoSettingsBuilder,
+    /// };
+    ///
+    /// let stream = InMemoryRandomAccessStream::new().unwrap();
+    ///
+    /// let encoder = VideoEncoder::new_from_stream(
+    ///     VideoSettingsBuilder::new(1920, 1080),
+    ///     AudioSettingsBuilder::new().disabled(true),
+    ///     ContainerSettingsBuilder::new(),
+    ///     stream.cast().unwrap(),
+    /// )
+    /// .unwrap();
+    /// ```
     #[inline]
     pub fn new_from_stream(
         video_settings: VideoSettingsBuilder,


### PR DESCRIPTION
Introduced a new example for stream-based encoding using `VideoEncoder::new_from_stream`, allowing in-memory video encoding for network streaming or further processing. Updated `Cargo.toml` to include the new example. Enhanced documentation in `encoder.rs` to reflect the new functionality.